### PR TITLE
fix: repoUrlPath error after jump

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,0 +1,25 @@
+chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
+  // if url changed
+  const platform = new URL(tab.url).host.split('.')[0];
+  const supportedPlatform = platform === 'github' || platform === 'gitlab';
+
+  if (changeInfo.status === 'complete' && (supportedPlatform)) {
+    debounce(chrome.tabs.sendMessage(tabId, { message: 'URL_CHANGED' }), 500);
+  };
+}
+);
+
+
+function debounce(func, wait) {
+  let timeout;
+
+  return function () {
+    let context = this;
+    let args = arguments;
+
+    clearTimeout(timeout);
+    timeout = setTimeout(function () {
+      func.apply(context, args)
+    }, wait);
+  }
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,8 +14,12 @@
       "128": "img/icon128.png"
     }
   },
+  "background": {
+    "service_worker": "js/background.js"
+  },
   "permissions": [
-    "storage"
+    "storage",
+    "tabs"
   ],
   "options_page": "html/options.html",
   "content_scripts": [


### PR DESCRIPTION
### What's happening? 
- Open https://github.com/vuejs/core
- Click on the vuejs organization in the top left corner 
- Click on the router library under the vuejs organization 
- Click on 'Open In Web IDE' 
- View link, still `vuejs/core`

### What did this PR do?
Fixed the above issue.