### PR TITLE
Update menuElement querySelector

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -246,12 +246,12 @@ function filterItems (item) {
 }
 
 function addGitHubSelectMenu () {
-  const selectors = [
+ // const selectors = [
     '.jxTzTd', // Repo main page
     '.faNtbn .d-flex.gap-2', // Repo files page
     '.gwHaUx .d-flex.gap-2' // Commits page
   ];
-  const menuElement = document.querySelector(selectors.join(', '));
+  const menuElement = document.querySelector('.react-directory-add-file-icon')?.parentElement?.parentElement
   if (!menuElement || menuElement.querySelector('#open-in-web-ide')) {
     return;
   }


### PR DESCRIPTION
Use the new selector to fix the bug where the extension not working due to GitHub's updates.

`document.querySelector('.react-directory-add-file-icon')?.parentElement?.parentElement`
![image](https://github.com/user-attachments/assets/2e6c9105-c221-4e31-a46e-a83eec6935c7)
